### PR TITLE
Llvm 3.8 review

### DIFF
--- a/plugins/llvm/llvm_binary.cpp
+++ b/plugins/llvm/llvm_binary.cpp
@@ -10,8 +10,7 @@ extern "C" {
     }
 
     const char* image_arch(const img::image* m) {
-        //return m->arch().c_str();
-        return (llvm::Triple::getArchTypeName(m->arch()));
+        return m->arch().c_str();
     }
 
     uint64_t image_entry(const img::image* m) {


### PR DESCRIPTION
First, this PR is not necessarily proposing finalized code. Rather, I want to open this up for discussion to determine where improvements can be made. It's still not done, and personally I would consider this to be less-than-average code.

Additionally, I reverted `image::arch_` from `std::string` back to `Triple::ArchType` because of the error that it was occurring with 16.04 Ubuntu. Following my submissions of this PR request, I'll turn towards determining the root of the problem such that a new PR can be opened where `arch_` is once again `std::string`.